### PR TITLE
bugfix: explictly assign CLI short-flag for encoding

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ struct Cli {
     /// Optional tokenizer to use for token count
     ///
     /// Supported tokenizers: cl100k (default), p50k, p50k_edit, r50k, gpt2
-    #[clap(short, long)]
+    #[clap(short = 'c', long)]
     encoding: Option<String>,
 
     /// Optional output file path


### PR DESCRIPTION
> Remember: sometimes fixing a bug is faster than opening an issue
> ~ `code2prompt`

# Before

```
cargo run -- --help                                                                                                     12:45:31 PM
   Compiling code2prompt v1.0.0 (/Users/vivek/Projects/code2prompt)
    Finished dev [unoptimized + debuginfo] target(s) in 0.67s
     Running `target/debug/code2prompt --help`
thread 'main' panicked at /Users/vivek/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.2/src/builder/debug_asserts.rs:112:17:
Command code2prompt: Short option names must be unique for each argument, but '-t' is in use by both 'template' and 'encoding'
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

# After

```
cargo run -- --help                                                                                      12:48:10 PM
   Compiling code2prompt v1.0.0 (/Users/vivek/Projects/code2prompt)
    Finished dev [unoptimized + debuginfo] target(s) in 0.53s
     Running `target/debug/code2prompt --help`
code2prompt is a command-line tool to generate an LLM prompt from a codebase directory.

Author: Mufeed VH (@mufeedvh)

Usage: code2prompt [OPTIONS] <PATH>

Arguments:
  <PATH>
          Path to the codebase directory

Options:
  -t, --template <TEMPLATE>
          Optional custom Handlebars template file path

  -f, --filter <FILTER>
          Optional comma-separated list of file extensions to filter

  -e, --exclude <EXCLUDE>
          Optional comma-separated list of file extensions to exclude

      --exclude-files <EXCLUDE_FILES>
          Optional comma-separated list of file names to exclude

      --exclude-folders <EXCLUDE_FOLDERS>
          Optional comma-separated list of folder paths to exclude

      --tokens
          Display the token count of the generated prompt

  -c, --encoding <ENCODING>
          Optional tokenizer to use for token count
          
          Supported tokenizers: cl100k (default), p50k, p50k_edit, r50k, gpt2

  -o, --output <OUTPUT>
          Optional output file path

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version
```