### PR TITLE
Add git diff generation and template for git commit message

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ ignore = "0.4.22"
 anyhow = "1.0.80"
 inquire = "0.7.1"
 regex = "1.10.3"
+git2 = "0.18.2"
 
 [profile.release]
 lto = "thin"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ You can customize the prompt template to achieve any of the desired use cases. I
 - Follows `.gitignore`.
 - Filter and exclude files by extension.
 - Display the token count of the generated prompt. (See [Tokenizers](#Tokenizers) for more details)
+- Optionally include the Git diff output (staged files) in the generated prompt.
 - Copy the generated prompt to the clipboard on generation.
 - Save the generated prompt to an output file.
 
@@ -114,6 +115,15 @@ Save the generated prompt to an output file:
 $ code2prompt path/to/codebase -o output.txt  
 ```
 
+Generate git committ message (for staged files):
+
+```
+$ code2prompt path/to/codebase --diff -t "templates/write-git-commit.hbs"    
+```
+
+
+
+
 ## Templates
 
 `code2prompt` comes with a set of built-in templates for common use cases. You can find them in the [`templates`](templates) directory.
@@ -137,6 +147,10 @@ Use this template to generate prompts for fixing bugs in the codebase. It will h
 ### [`write-github-readme.hbs`](templates/write-github-readme.hbs)
 
 Use this template to generate a high-quality README file for the project, suitable for hosting on GitHub. It will analyze the codebase to understand its purpose and functionality, and generate the README content in Markdown format.
+
+### [`write-git-commit.hbs`](templates/write-git-commit.hbs)
+
+Use this template to generate git commits from the staged files in your git directory. It will analyze the codebase to understand its purpose and functionality, and generate the git commit message content in Markdown format.
 
 ### [`improve-performance.hbs`](templates/improve-performance.hbs)
 

--- a/templates/write-git-commit.hbs
+++ b/templates/write-git-commit.hbs
@@ -1,0 +1,28 @@
+Project Path: {{ absolute_code_path }}
+
+I'd like you to generate a high-quality git commit message for the provided `git diff`. Analyze the diff to understand the purpose and functionality.
+
+Source Tree:
+```
+{{ source_tree }}
+```
+
+{{#if git_diff}}
+Diff:
+```
+{{git_diff}}
+```
+{{/if}}
+
+The git commit should adhere to these points:
+
+1. Concise Subject: Short and informative subject line, less than 50 characters.
+2. Descriptive Body: Optional summary of 1 to 2 sentences, wrapping at 72 characters.
+3. Use Imperative Mood: For example, "Fix bug" instead of "Fixed bug" or "Fixes bug."
+4. Capitalize the Subject: First letter of the subject should be capitalized.
+5. No Period at the End: Subject line does not end with a period.
+7. Separate Subject From Body With a Blank Line: If using a body, leave one blank line after the subject.
+
+Write the content in Markdown format. Use your analysis of the diff to generate a short, naccurate and helpful commit message.
+
+Feel free to infer reasonable details if needed, but try to stick to what can be determined from the diff itself. Let me know if you have any other questions as you're writing!


### PR DESCRIPTION
Add functionality to generate git diff and include it in the data passed to templates.

This adds a `--diff` CLI flag to generate the repo's diff. The diff text is included under the `"git_diff"` key in the `data` JSON object for templates.