### PR TITLE
feat: use "arboard" for cross-platform clipboard compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ clap = { version = "4.0", features = ["derive"] }
 handlebars = "4.3"
 jwalk = "0.8"
 termtree = "0.4"
-cli-clipboard = "0.4"
 serde_json = "1.0.114"
 indicatif = "0.17.8"
 colored = "2.1.0"
@@ -33,6 +32,7 @@ anyhow = "1.0.80"
 inquire = "0.7.1"
 regex = "1.10.3"
 git2 = { version = "0.18.2", default_features = false, features = [ "https", "vendored-libgit2", "vendored-openssl" ] }
+arboard = "3.4.0"
 
 [profile.release]
 lto = "thin"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
+use arboard::Clipboard;
 use clap::Parser;
 use colored::*;
 use git2::{DiffOptions, Repository};
@@ -204,7 +205,8 @@ fn main() {
         );
     }
 
-    cli_clipboard::set_contents(rendered.into()).expect("Failed to copy output to clipboard");
+    let mut clipboard = Clipboard::new().expect("Failed to initialize clipboard");
+    clipboard.set_text(rendered).expect("Failed to copy output to clipboard");
 
     println!(
         "{}{}{} {}",


### PR DESCRIPTION
Used arboard as per suggestion of [@RastislavKi](https://github.com/RastislavKish) for clipboard copying
