### PR TITLE
handle no clipboard more gracefully, prints to stdout

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -116,18 +116,15 @@ pub fn handle_undefined_variables(
 ///
 /// * `Result<()>` - An empty result indicating success or an error.
 pub fn copy_to_clipboard(rendered: &str) -> Result<()> {
-    let mut clipboard = Clipboard::new().expect("Failed to initialize clipboard");
-    clipboard
-        .set_text(rendered.to_string())
-        .context("Failed to copy to clipboard")?;
-    println!(
-        "{}{}{} {}",
-        "[".bold().white(),
-        "✓".bold().green(),
-        "]".bold().white(),
-        "Prompt copied to clipboard!".green()
-    );
-    Ok(())
+    match Clipboard::new() {
+        Ok(mut clipboard) => {
+            clipboard
+                .set_text(rendered.to_string())
+                .context("Failed to copy to clipboard")?;
+            Ok(())
+        }
+        Err(e) => Err(anyhow::anyhow!("Failed to initialize clipboard: {}", e)),
+    }
 }
 
 /// Writes the rendered template to a specified output file.


### PR DESCRIPTION
Small change to handle no clipboard error without panicking, will print to sdtout if no clipboard. Will close #26 

Seems like some minor formatting changes got included as well due to auto-formatter, let me know if that's a issue.