### PR TITLE
feat(help): show help menu on no args 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ const CUSTOM_TEMPLATE_NAME: &str = "custom";
 // CLI Arguments
 #[derive(Parser)]
 #[clap(name = "code2prompt", version = "2.0.0", author = "Mufeed VH")]
+#[command(arg_required_else_help = true)]
 struct Cli {
     /// Path to the codebase directory
     #[arg()]


### PR DESCRIPTION
This pr adds support for having help menu on no args. 

Before: 

<img width="581" alt="Screenshot 2024-09-15 at 6 39 48 PM" src="https://github.com/user-attachments/assets/b4e9959d-4b7e-432f-98bb-5d5f3649b8bb">

Now:

<img width="973" alt="Screenshot 2024-09-15 at 6 39 27 PM" src="https://github.com/user-attachments/assets/f450f8cd-2b37-4870-ab42-0484c0f9619a">

