### PR TITLE
Add flag for following symlinks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,10 @@ struct Cli {
     /// Print output as JSON
     #[clap(long)]
     json: bool,
+
+    /// Follow symlinks
+    #[clap(short = 'f', long)]
+    follow_symlinks: bool,
 }
 
 fn main() -> Result<()> {
@@ -121,6 +125,7 @@ fn main() -> Result<()> {
         args.relative_paths,
         args.exclude_from_tree,
         args.no_codeblock,
+        args.follow_symlinks,
     );
 
     let (tree, files) = match create_tree {

--- a/src/path.rs
+++ b/src/path.rs
@@ -33,6 +33,7 @@ pub fn traverse_directory(
     relative_paths: bool,
     exclude_from_tree: bool,
     no_codeblock: bool,
+    follow_symlinks: bool,
 ) -> Result<(String, Vec<serde_json::Value>)> {
     // ~~~ Initialization ~~~
     let mut files = Vec::new();
@@ -42,6 +43,7 @@ pub fn traverse_directory(
     // ~~~ Build the Tree ~~~
     let tree = WalkBuilder::new(&canonical_root_path)
         .git_ignore(true)
+        .follow_links(follow_symlinks)
         .build()
         .filter_map(|e| e.ok())
         .fold(Tree::new(parent_directory.to_owned()), |mut root, entry| {


### PR DESCRIPTION
Noticed that WalkBuilder, by default, ignores symlinks. I sometimes symlink random directories into my project such as folders from my Obsidian library. Hopefully this flag helps someone else! Didn't make it the default behavior to prevent breaking changes.