### PR TITLE
Documentation Deployment for code2prompt

### DIFF
--- a/.github/workflows/deploy-mdbook.yml
+++ b/.github/workflows/deploy-mdbook.yml
@@ -17,10 +17,12 @@ jobs:
         run: cargo install mdbook
 
       - name: Build the mdBook
+        working-directory: ./docs
         run: mdbook build
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./book
+          publish_dir: ./docs/book
+          publish_branch: gh-pages

--- a/.github/workflows/deploy-mdbook.yml
+++ b/.github/workflows/deploy-mdbook.yml
@@ -1,0 +1,26 @@
+name: Deploy mdBook to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install mdBook
+        run: cargo install mdbook
+
+      - name: Build the mdBook
+        run: mdbook build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./book


### PR DESCRIPTION
Hello @mufeedvh,

I redacted a documentation using **mdbook**. It can be deployed with a GitHub Action on GitHub Pages.

I already tested this on my fork and the result is already available [here](https://odancona.github.io/code2prompt/introduction.html).

**Changes**

- Added a GitHub Action to build and push documentation to the `gh-pages` branch.

**GitHub Pages Setup**

Navigate to `Repository Settings -> Pages` and set the source to `gh-pages` branch and `root` directory. The documentation should be available [there](https://mufeedvh.github.io/code2prompt/introduction.html).