### PR TITLE
Code2prompt should have sorting capabilities

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod filter;
 pub mod git;
 pub mod path;
 pub mod python;
+pub mod sort;
 pub mod template;
 pub mod token;
 pub mod util;
@@ -9,6 +10,7 @@ pub mod util;
 pub use filter::should_include_file;
 pub use git::{get_git_diff, get_git_diff_between_branches, get_git_log};
 pub use path::{label, traverse_directory};
+pub use sort::{sort_files, FileSortMethod};
 pub use template::{
     copy_to_clipboard, handle_undefined_variables, handlebars_setup, render_template, write_to_file,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub mod util;
 pub use filter::should_include_file;
 pub use git::{get_git_diff, get_git_diff_between_branches, get_git_log};
 pub use path::{label, traverse_directory};
-pub use sort::{sort_files, FileSortMethod};
+pub use sort::{sort_files, sort_tree, FileSortMethod};
 pub use template::{
     copy_to_clipboard, handle_undefined_variables, handlebars_setup, render_template, write_to_file,
 };

--- a/src/python.rs
+++ b/src/python.rs
@@ -60,7 +60,7 @@ impl CodePrompt {
         no_codeblock = false,
         follow_symlinks = false,
         hidden = false,
-        no_ignore = false
+        no_ignore = false,
     ))]
     fn new(
         path: String,
@@ -114,11 +114,13 @@ impl CodePrompt {
                 self.follow_symlinks,
                 self.hidden,
                 self.no_ignore,
+                None,
             )
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
 
             // Setup template
-            let template_content = template.unwrap_or_else(|| include_str!("default_template.hbs").to_string());
+            let template_content =
+                template.unwrap_or_else(|| include_str!("default_template.hbs").to_string());
             let handlebars = handlebars_setup(&template_content, "template")
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
 

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -1,0 +1,48 @@
+use serde_json::Value;
+
+///! Sorting methods for files.
+
+// Define the available sort methods.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileSortMethod {
+    NameAsc,  // Sort files alphabetically (A → Z)
+    NameDesc, // Sort files alphabetically in reverse (Z → A)
+    DateAsc,  // Sort files by modification date (oldest first)
+    DateDesc, // Sort files by modification date (newest first)
+}
+
+/// Sorts the provided `files` in place using the specified `sort_method`.
+///
+/// If `sort_method` is `None`, no sorting will be performed.
+///
+/// # Arguments
+///
+/// * `files` - A mutable slice of JSON values representing files. Each file is expected
+///             to have a `"path"` key (as a string) and a `"mod_time"` key (as a u64).
+/// * `sort_method` - An optional `FileSortMethod` indicating how to sort the files.
+pub fn sort_files(files: &mut Vec<Value>, sort_method: Option<FileSortMethod>) {
+    if let Some(method) = sort_method {
+        files.sort_by(|a, b| match method {
+            FileSortMethod::NameAsc => {
+                let a_path = a.get("path").and_then(Value::as_str).unwrap_or("");
+                let b_path = b.get("path").and_then(Value::as_str).unwrap_or("");
+                a_path.cmp(b_path)
+            }
+            FileSortMethod::NameDesc => {
+                let a_path = a.get("path").and_then(Value::as_str).unwrap_or("");
+                let b_path = b.get("path").and_then(Value::as_str).unwrap_or("");
+                b_path.cmp(a_path)
+            }
+            FileSortMethod::DateAsc => {
+                let a_time = a.get("mod_time").and_then(Value::as_u64).unwrap_or(0);
+                let b_time = b.get("mod_time").and_then(Value::as_u64).unwrap_or(0);
+                a_time.cmp(&b_time)
+            }
+            FileSortMethod::DateDesc => {
+                let a_time = a.get("mod_time").and_then(Value::as_u64).unwrap_or(0);
+                let b_time = b.get("mod_time").and_then(Value::as_u64).unwrap_or(0);
+                b_time.cmp(&a_time)
+            }
+        });
+    }
+}

--- a/tests/sort_test.rs
+++ b/tests/sort_test.rs
@@ -1,0 +1,126 @@
+use code2prompt::{sort_files, FileSortMethod};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_sort_files_name_asc() {
+        // Create a vector of file JSON objects with "path" and "mod_time"
+        let mut files = vec![
+            json!({"path": "zeta.txt", "mod_time": 100}),
+            json!({"path": "alpha.txt", "mod_time": 200}),
+            json!({"path": "beta.txt", "mod_time": 150}),
+        ];
+
+        // Sort by file name in ascending order (A → Z)
+        sort_files(&mut files, Some(FileSortMethod::NameAsc));
+
+        // Expected order is: "alpha.txt", "beta.txt", "zeta.txt"
+        let expected = vec!["alpha.txt", "beta.txt", "zeta.txt"];
+        let result: Vec<String> = files
+            .iter()
+            .map(|v| {
+                v.get("path")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("")
+                    .to_string()
+            })
+            .collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_sort_files_name_desc() {
+        // Create a vector of file JSON objects with "path" and "mod_time"
+        let mut files = vec![
+            json!({"path": "alpha.txt", "mod_time": 100}),
+            json!({"path": "zeta.txt", "mod_time": 200}),
+            json!({"path": "beta.txt", "mod_time": 150}),
+        ];
+
+        // Sort by file name in descending order (Z → A)
+        sort_files(&mut files, Some(FileSortMethod::NameDesc));
+
+        // Expected order is: "zeta.txt", "beta.txt", "alpha.txt"
+        let expected = vec!["zeta.txt", "beta.txt", "alpha.txt"];
+        let result: Vec<String> = files
+            .iter()
+            .map(|v| {
+                v.get("path")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("")
+                    .to_string()
+            })
+            .collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_sort_files_date_asc() {
+        // Create a vector of file JSON objects with "path" and "mod_time"
+        let mut files = vec![
+            json!({"path": "file1.txt", "mod_time": 300}),
+            json!({"path": "file2.txt", "mod_time": 100}),
+            json!({"path": "file3.txt", "mod_time": 200}),
+        ];
+
+        // Sort by modification time in ascending order (oldest first)
+        sort_files(&mut files, Some(FileSortMethod::DateAsc));
+
+        // Expected order is: "file2.txt" (100), "file3.txt" (200), "file1.txt" (300)
+        let expected = vec!["file2.txt", "file3.txt", "file1.txt"];
+        let result: Vec<String> = files
+            .iter()
+            .map(|v| {
+                v.get("path")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("")
+                    .to_string()
+            })
+            .collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_sort_files_date_desc() {
+        // Create a vector of file JSON objects with "path" and "mod_time"
+        let mut files = vec![
+            json!({"path": "file1.txt", "mod_time": 300}),
+            json!({"path": "file2.txt", "mod_time": 100}),
+            json!({"path": "file3.txt", "mod_time": 200}),
+        ];
+
+        // Sort by modification time in descending order (newest first)
+        sort_files(&mut files, Some(FileSortMethod::DateDesc));
+
+        // Expected order is: "file1.txt" (300), "file3.txt" (200), "file2.txt" (100)
+        let expected = vec!["file1.txt", "file3.txt", "file2.txt"];
+        let result: Vec<String> = files
+            .iter()
+            .map(|v| {
+                v.get("path")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("")
+                    .to_string()
+            })
+            .collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_sort_files_none() {
+        // When sort method is None, the original order should be preserved.
+        let original_files = vec![
+            json!({"path": "zeta.txt", "mod_time": 300}),
+            json!({"path": "alpha.txt", "mod_time": 100}),
+            json!({"path": "beta.txt", "mod_time": 200}),
+        ];
+        let mut files = original_files.clone();
+
+        // Sorting with None should leave the order unchanged.
+        sort_files(&mut files, None);
+        assert_eq!(files, original_files);
+    }
+}


### PR DESCRIPTION
Closes #54

`code2prompt` has now sorting abilities with the `--sort` flag

Currently supported sort:

- `sort_asc`
- `sort_desc`
- `date_asc`
- `date_desc`

Open questions:

1. The `ignore` crate has builtin sorting functionalities, should we use them, even they're potentially limited ?
2. The sorting is performed after the recursive tree exploration => is it worth exploring sorting progressively for performance reasons ?
