### PR TITLE
doc nit

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Supported tokenizers: `cl100k`, `p50k`, `p50k_edit`, `r50k_bas`.
 Save the generated prompt to an output file:
 
 ```sh
-code2prompt path/to/codebase --output=output.txt
+code2prompt path/to/codebase --output-file=output.txt
 ```
 
 Print output as JSON:


### PR DESCRIPTION
example shows --output flag when it really is --output-file flag

You have my permission to use my submission in any way you like.