### PR TITLE
Fix build errors in `clipboard.rs`: correct module import and result type

### DIFF
--- a/crates/code2prompt/src/clipboard.rs
+++ b/crates/code2prompt/src/clipboard.rs
@@ -13,8 +13,7 @@ use anyhow::Context;
 /// # Returns
 ///
 /// * `Result<()>` - Returns Ok on success, or an error if the clipboard could not be accessed.
-pub fn copy_text_to_clipboard(rendered: &str) -> Result<()> {
-    use anyhow::Result;
+pub fn copy_text_to_clipboard(rendered: &str) -> anyhow::Result<()> {
     use arboard::Clipboard;
     match Clipboard::new() {
         Ok(mut clipboard) => {

--- a/crates/code2prompt/src/main.rs
+++ b/crates/code2prompt/src/main.rs
@@ -211,7 +211,7 @@ fn main() -> Result<()> {
         }
         #[cfg(not(target_os = "linux"))]
         {
-            use code2prompt::copy_text_to_clipboard;
+            use crate::clipboard::copy_text_to_clipboard;
             match copy_text_to_clipboard(&rendered) {
                 Ok(_) => {
                     println!(


### PR DESCRIPTION
## Issue
When building the codebase, I encountered two main compilation errors:

1. Unable to resolve the module path `code2prompt::copy_text_to_clipboard` in `main.rs` (E0432)
1. Incomplete generic type specification for `Result<()>` in `clipboard.rs` which requires two type parameters (E0107)

### Environment

```shell
$ rustc --version
rustc 1.85.0 (4d91de4e4 2025-02-17)
$ cargo --version
cargo 1.85.0 (d73d2caf9 2024-12-31)
$ arch
arm64
$ uname
Darwin
```

### Raw build failure outputs

<details>
<summary>output</summary>

```
Compiling code2prompt v3.0.0 (/code2prompt/crates/code2prompt)
error[E0432]: unresolved import `code2prompt`
   --> crates/code2prompt/src/main.rs:214:17
    |
214 |             use code2prompt::copy_text_to_clipboard;
    |                 ^^^^^^^^^^^ use of undeclared crate or module `code2prompt`

warning: unused import: `anyhow::Result`
  --> crates/code2prompt/src/clipboard.rs:17:9
   |
17 |     use anyhow::Result;
   |         ^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

error[E0107]: enum takes 2 generic arguments but 1 generic argument was supplied
  --> crates/code2prompt/src/clipboard.rs:16:50
   |
16 | pub fn copy_text_to_clipboard(rendered: &str) -> Result<()> {
   |                                                  ^^^^^^ -- supplied 1 generic argument
   |                                                  |
   |                                                  expected 2 generic arguments
   |
help: add missing generic argument
   |
16 | pub fn copy_text_to_clipboard(rendered: &str) -> Result<(), E> {
   |                                                           +++

Some errors have detailed explanations: E0107, E0432.
For more information about an error, try `rustc --explain E0107`.
warning: `code2prompt` (bin "code2prompt") generated 1 warning
error: could not compile `code2prompt` (bin "code2prompt") due to 2 previous errors; 1 warning emitted
```

</details>

## Changes
This PR resolves the build errors with the following fixes:

1. Updated `main.rs` to use the correct module path for the clipboard functionality
1. Fixed the return type in `clipboard.rs` by explicitly using `anyhow::Result<()>`
1. Removed the unused import `use anyhow::Result;` to address the warning

## Testing
After these changes, I was able to successfully build the project with `cargo build --release` with no errors.

This change is purely a compilation fix and does not modify any functionality, so existing behavior remains unchanged.

## P.S.

I'm new to Rust, so feel free to close this PR if my approach isn't correct.
