### PR TITLE
Add Community Tools Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,9 @@ Ways to contribute:
 - Fix something and open a pull request
 - Help me document the code
 - Spread the word
+
+## Community Tools
+
+Here are some tools created by the community to enhance the code2prompt experience:
+
+- [**code2prompt-manager**](https://github.com/elvismdev/code2prompt-manager): A CLI tool that helps manage file size limits when using code2prompt. It provides an interactive interface to select which files to include/exclude from your codebase, automatically handles large files, and ensures your output stays under token limits for LLMs.

--- a/README_ES.md
+++ b/README_ES.md
@@ -268,6 +268,12 @@ Formas de contribuir:
 - Ayudarme a documentar el código
 - Difundir la palabra
 
+## Herramientas de la Comunidad
+
+Aquí hay algunas herramientas creadas por la comunidad para mejorar la experiencia de code2prompt:
+
+- [**code2prompt-manager**](https://github.com/elvismdev/code2prompt-manager): Una herramienta CLI que ayuda a gestionar los límites de tamaño de archivos al usar code2prompt. Proporciona una interfaz interactiva para seleccionar qué archivos incluir/excluir de tu código base, maneja automáticamente archivos grandes y asegura que tu output se mantenga por debajo de los límites de tokens para LLMs.
+
 ## Licencia
 
 Licenciado bajo la Licencia MIT, ver <a href="https://github.com/mufeedvh/code2prompt/blob/master/LICENSE">LICENSE</a> para más información.


### PR DESCRIPTION
This PR adds a new "Community Tools" section to the README's to highlight complementary tools created by the community that enhance the code2prompt experience.

The first tool added is [code2prompt-manager](https://github.com/elvismdev/code2prompt-manager), a CLI utility I created that helps users manage file size limits when working with large codebases. It provides an interactive interface for selecting files to include/exclude and ensures outputs stay under token limits for LLMs.

I've included both English and Spanish versions of the section to maintain consistency with the existing documentation.

Let me know if you'd like any changes to the wording or formatting.