### PR TITLE
Added support for .promptignore and custom ignore files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,7 @@ dependencies = [
  "assert_cmd",
  "colored",
  "derive_builder",
+ "dirs",
  "env_logger",
  "git2",
  "globset",
@@ -599,6 +600,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "dispatch2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +809,17 @@ checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
 dependencies = [
  "libc",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1084,7 +1117,7 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
  "libc",
 ]
 
@@ -1153,6 +1186,16 @@ checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
  "windows-targets 0.53.2",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+dependencies = [
+ "bitflags 2.9.1",
+ "libc",
 ]
 
 [[package]]
@@ -1438,6 +1481,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,6 +1755,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1936,7 +1996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
  "windows-sys 0.59.0",

--- a/crates/code2prompt-core/Cargo.toml
+++ b/crates/code2prompt-core/Cargo.toml
@@ -39,6 +39,7 @@ git2 = { workspace = true }
 once_cell = { workspace = true }
 globset = { workspace = true }
 derive_builder = { workspace = true }
+dirs = "5.0"
 
 [lib]
 name = "code2prompt_core"

--- a/crates/code2prompt-core/src/configuration.rs
+++ b/crates/code2prompt-core/src/configuration.rs
@@ -58,6 +58,14 @@ pub struct Code2PromptConfig {
     #[builder(default)]
     pub no_ignore: bool,
 
+    /// List of extra ignore files to use (e.g., .dockerignore, .npmignore).
+    #[builder(default)]
+    pub extra_ignore_files: Vec<String>,
+
+    /// If true, .promptignore rules will be ignored.
+    #[builder(default)]
+    pub no_promptignore: bool,
+
     /// Defines the sorting method for files.
     #[builder(default)]
     pub sort_method: Option<FileSortMethod>,

--- a/crates/code2prompt-python/src/python.rs
+++ b/crates/code2prompt-python/src/python.rs
@@ -184,6 +184,21 @@ impl PyCode2PromptSession {
         })
     }
 
+    fn with_extra_ignore_files(&mut self, files: Vec<String>) -> PyResult<Py<Self>> {
+        let mut config = self.inner.config.clone();
+        config.extra_ignore_files = files;
+        self.inner = Code2PromptSession::new(config);
+
+        Python::with_gil(|py| {
+            Ok(Py::new(
+                py,
+                Self {
+                    inner: self.inner.clone(),
+                },
+            )?)
+        })
+    }
+
     fn sort_by(&mut self, method: &str) -> PyResult<Py<Self>> {
         let mut config = self.inner.config.clone();
         match method.to_lowercase().as_str() {

--- a/crates/code2prompt/src/args.rs
+++ b/crates/code2prompt/src/args.rs
@@ -94,6 +94,14 @@ pub struct Cli {
     #[clap(long)]
     pub no_ignore: bool,
 
+    /// Extra ignore files to use (e.g., .dockerignore, .npmignore)
+    #[clap(short = 'E', long = "extra-ignore-files", value_delimiter = ',')]
+    pub extra_ignore_files: Vec<String>,
+
+    /// Skip .promptignore rules (both local and global)
+    #[clap(long)]
+    pub no_promptignore: bool,
+
     /// Sort order for files: one of "name_asc", "name_desc", "date_asc", or "date_desc"
     #[clap(long)]
     pub sort: Option<String>,

--- a/crates/code2prompt/src/main.rs
+++ b/crates/code2prompt/src/main.rs
@@ -119,10 +119,12 @@ fn main() -> Result<()> {
     // Boolean arguments
     configuration
         .no_ignore(args.no_ignore)
+        .no_promptignore(args.no_promptignore)
         .hidden(args.hidden)
         .no_codeblock(args.no_codeblock)
         .follow_symlinks(args.follow_symlinks)
-        .token_map_enabled(args.token_map);
+        .token_map_enabled(args.token_map)
+        .extra_ignore_files(args.extra_ignore_files);
 
     // ~~~ Code2Prompt ~~~
     let mut session = Code2PromptSession::new(configuration.build()?);

--- a/website/src/content/docs/docs/tutorials/learn_filters.mdx
+++ b/website/src/content/docs/docs/tutorials/learn_filters.mdx
@@ -29,6 +29,8 @@ Glob patterns allow you to specify rules for filtering files and directories.
 
 - **Include Patterns** (`--include`): Specify files and directories you want to include.
 - **Exclude Patterns** (`--exclude`): Specify files and directories you want to exclude.
+- **Extra Ignore Files** (`--extra-ignore-files`): Use custom ignore files (e.g., `.dockerignore`, `.npmignore`).
+- **Promptignore Control** (`--no-promptignore`): Disable .promptignore file processing.
 - **Priority** (`--include-priority`): Resolves conflicts between include and exclude patterns.
 
 ---
@@ -63,6 +65,12 @@ echo "CONTENT CORGE.txt" > "test_dir/uppercase/CORGE.TXT"
 echo "CONTENT GRAULT.txt" > "test_dir/uppercase/GRAULT.TXT"
 
 echo "top secret" > "test_dir/.secret/secret.txt"
+
+# Create sample ignore files for demonstration
+echo "*.txt" > "test_dir/.dockerignore"
+echo "uppercase/" > "test_dir/.npmignore"
+echo "*.log" > "test_dir/.promptignore"
+echo "grault*" > "test_dir/.promptignore"
 ```
 
 To clean up the structure later, run:
@@ -94,13 +102,16 @@ import { FileTree } from "@astrojs/starlight/components";
     - GRAULT.txt 
   - .secret 
     - secret.txt
+  - .dockerignore
+  - .npmignore
+  - .promptignore
 </FileTree>
 
 ---
 
 ## General Usage of `code2prompt`
 
-By default, `code2prompt` includes all files in the specified directory respecting the `.gitignore`.
+By default, `code2prompt` includes all files in the specified directory respecting the `.gitignore` and `.promptignore` files.
 
 
 
@@ -214,12 +225,159 @@ Excluded:
 
 - All files in `uppercase`
 
+---
+
+---
+
+## Using .promptignore Files
+
+Code2prompt supports `.promptignore` files that work similarly to `.gitignore` but are specifically designed for prompt generation. These files use the same syntax as `.gitignore` and allow you to exclude files from LLM prompts without affecting version control.
+
+### Case 9: Default .promptignore Behavior
+
+Code2prompt automatically respects `.promptignore` files in your project:
+
+```bash
+code2prompt test_dir
+```
+
+#### Result
+
+With our sample `.promptignore` containing `grault*`:
+
+Excluded:
+- `lowercase/grault.txt` (matches `grault*` pattern)
+- `uppercase/GRAULT.TXT` (matches `grault*` pattern)
+
+Included:
+- All other files
+
+---
+
+### Case 10: Disable .promptignore Processing
+
+You can disable `.promptignore` file processing while still respecting `.gitignore`:
+
+```bash
+code2prompt test_dir --no-promptignore
+```
+
+#### Result
+
+Included:
+- All files including those that would normally be excluded by `.promptignore`
+- `lowercase/grault.txt` and `uppercase/GRAULT.TXT` are now included
+
+---
+
+### Case 11: Global .promptignore Support
+
+Code2prompt also supports global `.promptignore` files in your home directory (`~/.promptignore`). These rules apply to all projects:
+
+```bash
+# Create a global .promptignore
+echo "*.log" >> ~/.promptignore
+echo "node_modules/" >> ~/.promptignore
+echo "build/" >> ~/.promptignore
+
+# Run code2prompt (will respect both local and global .promptignore)
+code2prompt test_dir
+```
+
+#### Result
+
+- Local `.promptignore` rules are applied first (higher precedence)
+- Global `~/.promptignore` rules are applied for patterns not covered locally
+- Both can be disabled with `--no-promptignore`
+
+---
+
+## Using Extra Ignore Files
+
+Code2prompt supports custom ignore files beyond `.gitignore`, allowing you to leverage existing project ignore patterns.
+
+### Case 12: Using Docker Ignore File
+
+Use `.dockerignore` to exclude files (which excludes `*.txt` files):
+
+```bash
+code2prompt test_dir --extra-ignore-files .dockerignore
+```
+
+#### Result
+
+Excluded:
+- All `.txt` files (`qux.txt`, `corge.txt`, `grault.txt`, `QUX.TXT`, `CORGE.TXT`, `GRAULT.TXT`, `secret.txt`)
+
+Included:
+- All `.py` files in both `lowercase` and `uppercase` directories
+
+---
+
+### Case 13: Using Multiple Extra Ignore Files
+
+Use both `.dockerignore` and `.npmignore`:
+
+```bash
+code2prompt test_dir --extra-ignore-files .dockerignore,.npmignore
+```
+
+#### Result
+
+Excluded:
+- All `.txt` files (from `.dockerignore`)
+- The entire `uppercase/` directory (from `.npmignore`)
+
+Included:
+- Only `.py` files in the `lowercase` directory
+
+---
+
+### Case 14: Combining Extra Ignore Files with Include/Exclude Patterns
+
+Use `.npmignore` but also exclude Python files:
+
+```bash
+code2prompt test_dir --extra-ignore-files .npmignore --exclude "*.py"
+```
+
+#### Result
+
+Excluded:
+- The entire `uppercase/` directory (from `.npmignore`)
+- All `.py` files (from `--exclude` pattern)
+
+Included:
+- Only `.txt` files in `lowercase` and `.secret` directories
+
+---
+
 ## Summary
 
 The glob pattern tool in `code2prompt` allows you to filter files and directories effectively using:
 
 - `--include` for specifying files to include
 - `--exclude` for files to exclude
+- `--no-promptignore` for disabling .promptignore file processing
+- `--extra-ignore-files` for using custom ignore files (e.g., `.dockerignore`, `.npmignore`)
 - `--include-priority` for resolving conflicts between patterns
+
+### Ignore File Precedence
+
+Code2prompt respects multiple types of ignore files with the following precedence (highest to lowest):
+
+1. `.ignore` files
+2. `.promptignore` files (local and global)
+3. Extra ignore files (specified with `--extra-ignore-files`)
+4. `.gitignore` files
+5. `.git/info/exclude`
+6. Global gitignore file
+
+### .promptignore Use Cases
+
+Maintain prompt-specific exclusions separate from version control:
+- Exclude static assets (images etc.) from being included in the output
+- Exclude testing code from being included in the output
+- Apply global rules across all projects via `~/.promptignore`
 
 To practice, set up the sample directory, try out the commands, and see how the tool filters files dynamically.


### PR DESCRIPTION
This PR implements `.promptignore` file support, allowing users to exclude files from LLM prompts without affecting version control. 

Also supports arbitrary ignore files through new flag `-E,--extra-ignore-files`

Typical use case:  to exclude assets (images etc. and generated code) from the output. 
* These files need to be tracked by git, but no need to send to LLM

Why the the [existing support for .ignore](https://docs.rs/ignore/latest/ignore/struct.WalkBuilder.html#method.ignore) is not enough?
* It serves different purpose: If we put files in .ignore, it would make them ignored by searchers like silver searcher and `rg`
* No global ~/.ignore support

## Implementation

This pull request adds support for `.promptignore` and custom ignore files to provide more flexible file filtering.

Key features:
- **`.promptignore` Support**: Automatically respects local and global `.promptignore` files.
- **Custom Ignore Files**: Use other ignore files like `.dockerignore` via the `--extra-ignore-files` flag.
- **Disable `.promptignore`**: A `--no-promptignore` flag has been added to bypass this feature.