### PR TITLE
fix linter style warning

### DIFF
--- a/crates/code2prompt/src/token_map.rs
+++ b/crates/code2prompt/src/token_map.rs
@@ -1,5 +1,6 @@
-use lscolors::{Indicator, LsColors};
+#[cfg(windows)]
 use log::error;
+use lscolors::{Indicator, LsColors};
 use serde::Deserialize;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BinaryHeap, HashMap};


### PR DESCRIPTION
fix unused import warning by moving `use` under the guard