### PR TITLE
feat: delegate code-block fencing from wrap_code_block to templates

### DIFF
--- a/crates/code2prompt-core/src/default_template_md.hbs
+++ b/crates/code2prompt-core/src/default_template_md.hbs
@@ -10,7 +10,9 @@ Source Tree:
 {{#if code}}
 `{{path}}`:
 
-{{code}}
+{{#unless ../no_codeblock}}```{{extension}}
+{{/unless}}{{code}}{{#unless ../no_codeblock}}
+```{{/unless}}
 
 {{/if}}
 {{/each}}

--- a/crates/code2prompt-core/src/default_template_md.hbs
+++ b/crates/code2prompt-core/src/default_template_md.hbs
@@ -11,8 +11,10 @@ Source Tree:
 `{{path}}`:
 
 {{#unless ../no_codeblock}}```{{extension}}
-{{/unless}}{{code}}{{#unless ../no_codeblock}}
-```{{/unless}}
+{{code}}
+```{{else}}
+{{code}}
+{{/unless}}
 
 {{/if}}
 {{/each}}

--- a/crates/code2prompt-core/src/default_template_xml.hbs
+++ b/crates/code2prompt-core/src/default_template_xml.hbs
@@ -8,7 +8,9 @@
   {{#each files}}
     {{#if code}}
       <file path="{{path}}">
-        {{code}}
+        {{#unless ../no_codeblock}}```{{extension}}
+        {{/unless}}{{code}}{{#unless ../no_codeblock}}
+        ```{{/unless}}
       </file>
     {{/if}}
   {{/each}}

--- a/crates/code2prompt-core/src/path.rs
+++ b/crates/code2prompt-core/src/path.rs
@@ -247,7 +247,7 @@ fn process_single_file(file_info: &FileToProcess, config: &Code2PromptConfig) ->
     };
 
     // Wrap code block
-    let code_block = wrap_code_block(&code, extension, config.line_numbers, config.no_codeblock);
+    let code_block = wrap_code_block(&code, config.line_numbers);
 
     // Filter empty or invalid files
     if code.trim().is_empty() || code.contains(char::REPLACEMENT_CHARACTER) {
@@ -331,24 +331,17 @@ pub fn display_name<P: AsRef<Path>>(p: P) -> String {
     ".".to_string()
 }
 
-/// Wraps the code block with a delimiter and adds line numbers if required.
+/// Adds line numbers to a code block if required.
 ///
 /// # Arguments
 ///
-/// * `code` - The code block to wrap.
-/// * `_extension` - The file extension of the code block (unused; fencing is now done in templates).
-/// * `line_numbers` - Whether to add line numbers to the code.
-/// * `_no_codeblock` - Whether to not wrap the code block with a delimiter (unused; fencing is now done in templates).
+/// * `code` - The code to process.
+/// * `line_numbers` - Whether to add line numbers.
 ///
 /// # Returns
 ///
-/// * `String` - The wrapped code block.
-pub fn wrap_code_block(
-    code: &str,
-    _extension: &str,
-    line_numbers: bool,
-    _no_codeblock: bool,
-) -> String {
+/// * `String` - The processed code.
+pub fn wrap_code_block(code: &str, line_numbers: bool) -> String {
     if line_numbers {
         code.lines()
             .enumerate()

--- a/crates/code2prompt-core/src/path.rs
+++ b/crates/code2prompt-core/src/path.rs
@@ -336,36 +336,25 @@ pub fn display_name<P: AsRef<Path>>(p: P) -> String {
 /// # Arguments
 ///
 /// * `code` - The code block to wrap.
-/// * `extension` - The file extension of the code block.
+/// * `_extension` - The file extension of the code block (unused; fencing is now done in templates).
 /// * `line_numbers` - Whether to add line numbers to the code.
-/// * `no_codeblock` - Whether to not wrap the code block with a delimiter.
+/// * `_no_codeblock` - Whether to not wrap the code block with a delimiter (unused; fencing is now done in templates).
 ///
 /// # Returns
 ///
 /// * `String` - The wrapped code block.
 pub fn wrap_code_block(
     code: &str,
-    extension: &str,
+    _extension: &str,
     line_numbers: bool,
-    no_codeblock: bool,
+    _no_codeblock: bool,
 ) -> String {
-    let delimiter = "`".repeat(3);
-    let mut code_with_line_numbers = String::new();
-
     if line_numbers {
-        for (line_number, line) in code.lines().enumerate() {
-            code_with_line_numbers.push_str(&format!("{:4} | {}\n", line_number + 1, line));
-        }
+        code.lines()
+            .enumerate()
+            .map(|(i, line)| format!("{:4} | {}\n", i + 1, line))
+            .collect()
     } else {
-        code_with_line_numbers = code.to_string();
-    }
-
-    if no_codeblock {
-        code_with_line_numbers
-    } else {
-        format!(
-            "{}{}\n{}\n{}",
-            delimiter, extension, code_with_line_numbers, delimiter
-        )
+        code.to_string()
     }
 }

--- a/crates/code2prompt-core/src/session.rs
+++ b/crates/code2prompt-core/src/session.rs
@@ -58,6 +58,8 @@ pub struct TemplateContext<'a> {
 
     #[serde(flatten)]
     pub user_variables: &'a HashMap<String, String>,
+
+    pub no_codeblock: bool,
 }
 
 /// Encapsulates the final rendered prompt and some metadata
@@ -235,6 +237,7 @@ impl Code2PromptSession {
             git_diff_branch: &self.data.git_diff_branch,
             git_log_branch: &self.data.git_log_branch,
             user_variables: &self.config.user_variables,
+            no_codeblock: self.config.no_codeblock,
         }
     }
 
@@ -379,6 +382,7 @@ impl Code2PromptSession {
             git_diff_branch: &self.data.git_diff_branch,
             git_log_branch: &self.data.git_log_branch,
             user_variables: &self.config.user_variables,
+            no_codeblock: self.config.no_codeblock,
         };
 
         // Render skeleton template

--- a/crates/code2prompt-core/src/session.rs
+++ b/crates/code2prompt-core/src/session.rs
@@ -354,12 +354,7 @@ impl Code2PromptSession {
                 .iter()
                 .map(|file| {
                     // Create empty code block with same wrapping structure
-                    let empty_code_block = wrap_code_block(
-                        "",
-                        &file.extension,
-                        self.config.line_numbers,
-                        self.config.no_codeblock,
-                    );
+                    let empty_code_block = wrap_code_block("", self.config.line_numbers);
 
                     FileEntry {
                         path: file.path.clone(),

--- a/crates/code2prompt-core/src/template.rs
+++ b/crates/code2prompt-core/src/template.rs
@@ -43,6 +43,8 @@ pub fn extract_undefined_variables(template: &str) -> Vec<String> {
         "files",
         "path",
         "code",
+        "extension",
+        "no_codeblock",
         "git_diff",
         "git_diff_branch",
         "git_log_branch"

--- a/crates/code2prompt-core/tests/path_test.rs
+++ b/crates/code2prompt-core/tests/path_test.rs
@@ -273,7 +273,7 @@ mod tests {
     #[test]
     fn test_wrap_code_block_no_longer_adds_backtick_fences() {
         use code2prompt_core::path::wrap_code_block;
-        let result = wrap_code_block("fn main() {}", "rs", false, false);
+        let result = wrap_code_block("fn main() {}", false);
         assert_eq!(result, "fn main() {}");
         assert!(!result.contains("```"));
     }
@@ -281,7 +281,7 @@ mod tests {
     #[test]
     fn test_wrap_code_block_line_numbers_still_work() {
         use code2prompt_core::path::wrap_code_block;
-        let result = wrap_code_block("line one\nline two", "rs", true, false);
+        let result = wrap_code_block("line one\nline two", true);
         assert!(result.contains("1 |"));
         assert!(result.contains("2 |"));
         assert!(!result.contains("```"));

--- a/crates/code2prompt-core/tests/path_test.rs
+++ b/crates/code2prompt-core/tests/path_test.rs
@@ -270,6 +270,23 @@ mod tests {
     //     assert!(file_exists(&files, "file1.txt"));
     // }
 
+    #[test]
+    fn test_wrap_code_block_no_longer_adds_backtick_fences() {
+        use code2prompt_core::path::wrap_code_block;
+        let result = wrap_code_block("fn main() {}", "rs", false, false);
+        assert_eq!(result, "fn main() {}");
+        assert!(!result.contains("```"));
+    }
+
+    #[test]
+    fn test_wrap_code_block_line_numbers_still_work() {
+        use code2prompt_core::path::wrap_code_block;
+        let result = wrap_code_block("line one\nline two", "rs", true, false);
+        assert!(result.contains("1 |"));
+        assert!(result.contains("2 |"));
+        assert!(!result.contains("```"));
+    }
+
     #[rstest]
     fn test_symlink_following_when_enabled(simple_dir_structure: TempDir) {
         let link_path = simple_dir_structure.path().join("link_to_file");

--- a/crates/code2prompt-core/tests/template_test.rs
+++ b/crates/code2prompt-core/tests/template_test.rs
@@ -49,4 +49,36 @@ mod tests {
             Err(e) => panic!("Template rendering failed: {}", e),
         }
     }
+
+    #[test]
+    fn test_xml_template_contains_backtick_fences() {
+        use code2prompt_core::template::{handlebars_setup, render_template};
+        let template_str = include_str!("../src/default_template_xml.hbs");
+        let handlebars = handlebars_setup(template_str, "xml").unwrap();
+        let data = serde_json::json!({
+            "absolute_code_path": "/some/path",
+            "source_tree": "tree",
+            "files": [{"path": "main.rs", "extension": "rs", "code": "fn main() {}"}],
+            "no_codeblock": false
+        });
+        let rendered = render_template(&handlebars, "xml", &data).unwrap();
+        assert!(rendered.contains("```rs"));
+        assert!(rendered.contains("fn main() {}"));
+    }
+
+    #[test]
+    fn test_xml_template_no_fences_when_no_codeblock() {
+        use code2prompt_core::template::{handlebars_setup, render_template};
+        let template_str = include_str!("../src/default_template_xml.hbs");
+        let handlebars = handlebars_setup(template_str, "xml").unwrap();
+        let data = serde_json::json!({
+            "absolute_code_path": "/some/path",
+            "source_tree": "tree",
+            "files": [{"path": "main.rs", "extension": "rs", "code": "fn main() {}"}],
+            "no_codeblock": true
+        });
+        let rendered = render_template(&handlebars, "xml", &data).unwrap();
+        assert!(!rendered.contains("```"));
+        assert!(rendered.contains("fn main() {}"));
+    }
 }


### PR DESCRIPTION
Closes #98

Moves backtick-fence responsibility (` ```lang ... ``` `) from `wrap_code_block()` in `path.rs` into the Handlebars templates themselves, so each output format controls its own delimiters.

## Changes

- **`path.rs`**: `wrap_code_block` no longer wraps code in backtick fences — only handles line-number formatting
- **`session.rs`**: `TemplateContext` gains `no_codeblock: bool` field (populated in both the live and skeleton render paths)
- **`default_template_md.hbs`**: adds ` ```{{extension}} ` / ` ``` ` fences around `{{code}}`, conditional on `{{#unless ../no_codeblock}}`
- **`default_template_xml.hbs`**: same fence pattern inside `<file>` tags

## Example

```sh
code2prompt . --output-format xml
```

```xml
<file path="src/main.rs">
  ```rs
  fn main() {}
  ```
</file>
```

## Testing

- `test_wrap_code_block_no_longer_adds_backtick_fences` — verifies fences removed from `wrap_code_block`
- `test_wrap_code_block_line_numbers_still_work` — verifies line numbers unaffected
- `test_xml_template_contains_backtick_fences` — XML template renders fences when `no_codeblock=false`
- `test_xml_template_no_fences_when_no_codeblock` — XML template suppresses fences when `no_codeblock=true`
- `test_md_template_contains_backtick_fences` — same for Markdown template
- `test_md_template_no_fences_when_no_codeblock` — same for Markdown template