### PR TITLE
feat(core): make ipynb file processor configurable

### DIFF
--- a/crates/code2prompt-core/src/configuration.rs
+++ b/crates/code2prompt-core/src/configuration.rs
@@ -2,6 +2,7 @@
 //! of code2prompt in a stateless manner. It includes all parameters needed for file traversal,
 //! code filtering, token counting, and more.
 
+use crate::file_processor::FileProcessorsConfig;
 use crate::template::OutputFormat;
 use crate::tokenizer::TokenizerType;
 use crate::{sort::FileSortMethod, tokenizer::TokenFormat};
@@ -118,6 +119,9 @@ pub struct Code2PromptConfig {
 
     /// If true, starts with all files deselected.
     pub deselected: bool,
+
+    /// Settings for file-type processors (e.g. Jupyter notebooks).
+    pub processors: FileProcessorsConfig,
 }
 
 impl Code2PromptConfig {
@@ -184,6 +188,9 @@ pub struct TomlConfig {
 
     /// Initial selection state
     pub deselected: bool,
+
+    /// File processor settings (nested tables such as `[processors.ipynb]`)
+    pub processors: FileProcessorsConfig,
 }
 
 impl TomlConfig {
@@ -245,7 +252,8 @@ impl TomlConfig {
         builder
             .user_variables(self.user_variables.clone())
             .token_map_enabled(self.token_map_enabled)
-            .deselected(self.deselected);
+            .deselected(self.deselected)
+            .processors(self.processors.clone());
 
         builder.build().unwrap_or_default()
     }
@@ -287,6 +295,7 @@ pub fn export_config_to_toml(config: &Code2PromptConfig) -> Result<String, toml:
         user_variables: config.user_variables.clone(),
         token_map_enabled: config.token_map_enabled,
         deselected: config.deselected,
+        processors: config.processors.clone(),
     };
 
     toml_config.to_string()

--- a/crates/code2prompt-core/src/file_processor/ipynb.rs
+++ b/crates/code2prompt-core/src/file_processor/ipynb.rs
@@ -2,18 +2,94 @@
 //!
 //! This processor parses Jupyter notebook JSON and extracts:
 //! - Total number of cells and their types
-//! - Code cells only (ignoring markdown and raw cells)
-//! - First 2-3 code cells as samples
+//! - Code cells (and optionally markdown cells)
+//! - A configurable number of sample cells
+//! - Optional cell outputs
 //!
 //! This provides LLMs with notebook structure context without overwhelming them with all cells.
 
-use super::{DefaultTextProcessor, FileProcessor};
+use super::{DefaultTextProcessor, FileProcessor, IpynbProcessorConfig};
 use anyhow::{Context, Result};
 use serde_json::Value;
 use std::path::Path;
 
 /// Jupyter Notebook processor that extracts code cells and metadata.
-pub struct JupyterNotebookProcessor;
+pub struct JupyterNotebookProcessor {
+    config: IpynbProcessorConfig,
+}
+
+impl Default for JupyterNotebookProcessor {
+    fn default() -> Self {
+        Self {
+            config: IpynbProcessorConfig::default(),
+        }
+    }
+}
+
+impl JupyterNotebookProcessor {
+    /// Create a processor with the given configuration.
+    pub fn new(config: IpynbProcessorConfig) -> Self {
+        Self { config }
+    }
+
+    fn extract_source(source: &Value) -> String {
+        match source {
+            Value::String(s) => s.clone(),
+            Value::Array(arr) => arr
+                .iter()
+                .filter_map(|v| v.as_str())
+                .collect::<Vec<_>>()
+                .join(""),
+            _ => String::from("(Unable to extract source)"),
+        }
+    }
+
+    fn append_outputs(output: &mut String, cell: &Value) {
+        let Some(outputs) = cell.get("outputs").and_then(|v| v.as_array()) else {
+            return;
+        };
+        if outputs.is_empty() {
+            return;
+        }
+
+        output.push_str("Output:\n");
+        for out in outputs {
+            let output_type = out.get("output_type").and_then(|v| v.as_str()).unwrap_or("");
+            match output_type {
+                "stream" => {
+                    if let Some(text) = out.get("text") {
+                        let text = Self::extract_source(text);
+                        output.push_str(&text);
+                        if !text.ends_with('\n') {
+                            output.push('\n');
+                        }
+                    }
+                }
+                "execute_result" | "display_data" => {
+                    if let Some(data) = out.get("data")
+                        && let Some(text) = data.get("text/plain")
+                    {
+                        let text = Self::extract_source(text);
+                        output.push_str(&text);
+                        if !text.ends_with('\n') {
+                            output.push('\n');
+                        }
+                    }
+                }
+                "error" => {
+                    let ename = out
+                        .get("ename")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("Error");
+                    let evalue = out.get("evalue").and_then(|v| v.as_str()).unwrap_or("");
+                    output.push_str(&format!("{}: {}\n", ename, evalue));
+                }
+                _ => {}
+            }
+        }
+        output.push('\n');
+    }
+}
 
 impl FileProcessor for JupyterNotebookProcessor {
     fn process(&self, content: &[u8], _path: &Path) -> Result<String> {
@@ -27,8 +103,9 @@ impl FileProcessor for JupyterNotebookProcessor {
             .and_then(|v| v.as_array())
             .context("Notebook has no 'cells' array")?;
 
-        // Count cell types
+        // Count cell types and collect code / markdown cells
         let mut code_cells = Vec::new();
+        let mut markdown_cells = Vec::new();
         let mut markdown_count = 0;
         let mut raw_count = 0;
 
@@ -40,7 +117,10 @@ impl FileProcessor for JupyterNotebookProcessor {
 
             match cell_type {
                 "code" => code_cells.push(cell),
-                "markdown" => markdown_count += 1,
+                "markdown" => {
+                    markdown_count += 1;
+                    markdown_cells.push(cell);
+                }
                 "raw" => raw_count += 1,
                 _ => {}
             }
@@ -59,30 +139,33 @@ impl FileProcessor for JupyterNotebookProcessor {
             raw_count
         ));
 
+        if self.config.include_markdown {
+            for (idx, cell) in markdown_cells.iter().enumerate() {
+                output.push_str(&format!("Markdown Cell #{}:\n", idx + 1));
+                if let Some(source) = cell.get("source") {
+                    let text = Self::extract_source(source);
+                    output.push_str(&text);
+                    if !text.ends_with('\n') {
+                        output.push('\n');
+                    }
+                    output.push('\n');
+                }
+            }
+        }
+
         if code_cells.is_empty() {
             output.push_str("(No code cells found)\n");
             return Ok(output);
         }
 
-        // Show first 2-3 code cells
-        let max_cells_to_show = 3.min(code_cells.len());
+        let max_cells_to_show = self.config.max_code_cells.min(code_cells.len());
 
         for (idx, cell) in code_cells.iter().take(max_cells_to_show).enumerate() {
             output.push_str(&format!("Code Cell #{}:\n", idx + 1));
 
             // Extract source code
             if let Some(source) = cell.get("source") {
-                let code = match source {
-                    Value::String(s) => s.clone(),
-                    Value::Array(arr) => {
-                        // Join array of strings
-                        arr.iter()
-                            .filter_map(|v| v.as_str())
-                            .collect::<Vec<_>>()
-                            .join("")
-                    }
-                    _ => String::from("(Unable to extract source)"),
-                };
+                let code = Self::extract_source(source);
 
                 output.push_str("```python\n");
                 output.push_str(&code);
@@ -90,6 +173,10 @@ impl FileProcessor for JupyterNotebookProcessor {
                     output.push('\n');
                 }
                 output.push_str("```\n\n");
+            }
+
+            if self.config.include_outputs {
+                Self::append_outputs(&mut output, cell);
             }
         }
 

--- a/crates/code2prompt-core/src/file_processor/mod.rs
+++ b/crates/code2prompt-core/src/file_processor/mod.rs
@@ -5,6 +5,7 @@
 //! raw data where applicable. (e.g., schema + sample for CSV, code cells for Jupyter notebooks).
 
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 mod csv;
@@ -18,6 +19,44 @@ pub use default::DefaultTextProcessor;
 pub use ipynb::JupyterNotebookProcessor;
 pub use jsonl::JsonLinesProcessor;
 pub use tsv::TsvProcessor;
+
+/// Configuration for the Jupyter notebook (`.ipynb`) file processor.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct IpynbProcessorConfig {
+    /// Maximum number of code cells to include in the processed output.
+    ///
+    /// Default: `3`
+    pub max_code_cells: usize,
+
+    /// When true, include cell outputs (stdout / text/plain / errors) after each code cell.
+    ///
+    /// Default: `false`
+    pub include_outputs: bool,
+
+    /// When true, include markdown cells in the processed output.
+    ///
+    /// Default: `false`
+    pub include_markdown: bool,
+}
+
+impl Default for IpynbProcessorConfig {
+    fn default() -> Self {
+        Self {
+            max_code_cells: 3,
+            include_outputs: false,
+            include_markdown: false,
+        }
+    }
+}
+
+/// Configuration for all file processors.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct FileProcessorsConfig {
+    /// Jupyter notebook processor settings.
+    pub ipynb: IpynbProcessorConfig,
+}
 
 /// Trait for processing file contents into LLM-optimized string representations.
 ///
@@ -43,29 +82,20 @@ pub trait FileProcessor: Send + Sync {
 /// # Arguments
 ///
 /// * `extension` - File extension (without dot)
+/// * `processors` - Processor configuration (used by configurable processors such as ipynb)
 ///
 /// # Returns
 ///
 /// * `Box<dyn FileProcessor>` - Processor instance for the given extension
-///
-/// # Examples
-///
-/// ```rs
-/// use std::path::Path;
-/// use code2prompt_core::file_processor::get_processor_for_extension;
-///
-/// let processor = get_processor_for_extension("csv");
-/// let bytes = b"column1,column2\nvalue1,value2";
-/// let path = Path::new("fake_file.csv");
-/// 
-/// let result = processor.process(bytes, path).unwrap(); 
-/// ```
-pub fn get_processor_for_extension(extension: &str) -> Box<dyn FileProcessor> {
+pub fn get_processor_for_extension(
+    extension: &str,
+    processors: &FileProcessorsConfig,
+) -> Box<dyn FileProcessor> {
     match extension.to_lowercase().as_str() {
         "csv" => Box::new(CsvProcessor),
         "tsv" => Box::new(TsvProcessor),
         "jsonl" | "ndjson" => Box::new(JsonLinesProcessor),
-        "ipynb" => Box::new(JupyterNotebookProcessor),
+        "ipynb" => Box::new(JupyterNotebookProcessor::new(processors.ipynb.clone())),
         // Future processors can be added here:
         // "parquet" => Box::new(ParquetProcessor),
         // "xml" => Box::new(XmlProcessor),

--- a/crates/code2prompt-core/src/path.rs
+++ b/crates/code2prompt-core/src/path.rs
@@ -237,7 +237,8 @@ fn process_single_file(file_info: &FileToProcess, config: &Code2PromptConfig) ->
 
     // Get appropriate processor for file extension
     let extension = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
-    let processor = file_processor::get_processor_for_extension(extension);
+    let processor =
+        file_processor::get_processor_for_extension(extension, &config.processors);
 
     // Process file content
     let code = match processor.process(clean_bytes, path) {

--- a/crates/code2prompt-core/tests/file_processor_test.rs
+++ b/crates/code2prompt-core/tests/file_processor_test.rs
@@ -202,7 +202,7 @@ mod ipynb_tests {
 
     #[test]
     fn test_ipynb_with_code_cells() {
-        let processor = JupyterNotebookProcessor;
+        let processor = JupyterNotebookProcessor::default();
         let content = r##"{
             "cells": [
                 {
@@ -230,11 +230,12 @@ mod ipynb_tests {
         assert!(result.contains("import pandas as pd"));
         assert!(result.contains("Code Cell #2:"));
         assert!(result.contains("df.head()"));
+        assert!(!result.contains("Markdown Cell"));
     }
 
     #[test]
     fn test_ipynb_with_many_code_cells() {
-        let processor = JupyterNotebookProcessor;
+        let processor = JupyterNotebookProcessor::default();
         let content = r#"{
             "cells": [
                 {"cell_type": "code", "source": "cell1"},
@@ -258,8 +259,80 @@ mod ipynb_tests {
     }
 
     #[test]
+    fn test_ipynb_custom_max_code_cells() {
+        let processor = JupyterNotebookProcessor::new(IpynbProcessorConfig {
+            max_code_cells: 5,
+            ..IpynbProcessorConfig::default()
+        });
+        let content = r#"{
+            "cells": [
+                {"cell_type": "code", "source": "cell1"},
+                {"cell_type": "code", "source": "cell2"},
+                {"cell_type": "code", "source": "cell3"},
+                {"cell_type": "code", "source": "cell4"},
+                {"cell_type": "code", "source": "cell5"}
+            ]
+        }"#;
+
+        let result = processor
+            .process(content.as_bytes(), &PathBuf::from("test.ipynb"))
+            .unwrap();
+
+        assert!(result.contains("Code Cell #5:"));
+        assert!(!result.contains("omitted"));
+    }
+
+    #[test]
+    fn test_ipynb_include_outputs() {
+        let processor = JupyterNotebookProcessor::new(IpynbProcessorConfig {
+            include_outputs: true,
+            ..IpynbProcessorConfig::default()
+        });
+        let content = r#"{
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "source": "print('hi')",
+                    "outputs": [
+                        {"output_type": "stream", "name": "stdout", "text": ["hi\n"]}
+                    ]
+                }
+            ]
+        }"#;
+
+        let result = processor
+            .process(content.as_bytes(), &PathBuf::from("test.ipynb"))
+            .unwrap();
+
+        assert!(result.contains("Output:"));
+        assert!(result.contains("hi"));
+    }
+
+    #[test]
+    fn test_ipynb_include_markdown() {
+        let processor = JupyterNotebookProcessor::new(IpynbProcessorConfig {
+            include_markdown: true,
+            ..IpynbProcessorConfig::default()
+        });
+        let content = r##"{
+            "cells": [
+                {"cell_type": "markdown", "source": "# Title"},
+                {"cell_type": "code", "source": "x = 1"}
+            ]
+        }"##;
+
+        let result = processor
+            .process(content.as_bytes(), &PathBuf::from("test.ipynb"))
+            .unwrap();
+
+        assert!(result.contains("Markdown Cell #1:"));
+        assert!(result.contains("# Title"));
+        assert!(result.contains("Code Cell #1:"));
+    }
+
+    #[test]
     fn test_ipynb_no_code_cells() {
-        let processor = JupyterNotebookProcessor;
+        let processor = JupyterNotebookProcessor::default();
         let content = r##"{
             "cells": [
                 {"cell_type": "markdown", "source": "# Title"},
@@ -277,7 +350,7 @@ mod ipynb_tests {
 
     #[test]
     fn test_ipynb_invalid_json() {
-        let processor = JupyterNotebookProcessor;
+        let processor = JupyterNotebookProcessor::default();
         let content = b"not a valid json";
 
         let result = processor.process(content, &PathBuf::from("test.ipynb"));
@@ -286,7 +359,7 @@ mod ipynb_tests {
 
     #[test]
     fn test_ipynb_with_fallback() {
-        let processor = JupyterNotebookProcessor;
+        let processor = JupyterNotebookProcessor::default();
         let content = b"invalid notebook content";
 
         let result = processor

--- a/crates/code2prompt/tests/config_test.rs
+++ b/crates/code2prompt/tests/config_test.rs
@@ -38,6 +38,11 @@ token_map_enabled = true
 [user_variables]
 project = "code2prompt"
 author = "ODAncona"
+
+[processors.ipynb]
+max_code_cells = 10
+include_outputs = true
+include_markdown = false
 "#;
 
     use code2prompt_core::configuration::TomlConfig;
@@ -82,6 +87,13 @@ author = "ODAncona"
         config.user_variables.get("author"),
         Some(&"ODAncona".to_string())
     );
+    assert_eq!(config.processors.ipynb.max_code_cells, 10);
+    assert!(config.processors.ipynb.include_outputs);
+    assert!(!config.processors.ipynb.include_markdown);
+
+    let core = config.to_code2prompt_config();
+    assert_eq!(core.processors.ipynb.max_code_cells, 10);
+    assert!(core.processors.ipynb.include_outputs);
 }
 
 /// Test TOML config export functionality


### PR DESCRIPTION
## Summary
- Add `[processors.ipynb]` config for `max_code_cells`, `include_outputs`, and `include_markdown`
- Wire settings through `Code2PromptConfig` / `TomlConfig` into `JupyterNotebookProcessor`
- Defaults match previous behavior (3 code cells, no outputs, no markdown)

Fixes #264

### Example `.c2pconfig`
```toml
[processors.ipynb]
max_code_cells = 10
include_outputs = true
include_markdown = false
```

## Test plan
- [x] `cargo test -p code2prompt_core --test file_processor_test` (24 passed)
- [ ] CI green


Made with [Cursor](https://cursor.com)